### PR TITLE
add instrumentation events to checkout bridge

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutBridge.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutBridge.kt
@@ -45,7 +45,10 @@ internal class CheckoutBridge(
 
         fun instrument(webView: WebView, payload: InstrumentationPayload) {
             val event = SdkToWebEvent(payload)
-            webView.evaluateJavascript("setTimeout(()=> {window.MobileCheckoutSdk.dispatchMessage('instrumentation', ${Json.encodeToString(event)}); }, 2000)", null)
+            val json = Json.encodeToString(event)
+            webView.evaluateJavascript(
+                "setTimeout(()=> {window.MobileCheckoutSdk.dispatchMessage('instrumentation', $json); }, 1000)",
+                null)
         }
     }
 
@@ -101,6 +104,6 @@ internal data class InstrumentationPayload(
 
 @Serializable
 internal enum class InstrumentationType {
-    histogram, incrementCounter
+    Histogram, IncrementCounter
 }
 

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutBridge.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutBridge.kt
@@ -102,8 +102,9 @@ internal data class InstrumentationPayload(
     val tags: Map<String, String>
 )
 
+@Suppress("EnumEntryName", "EnumNaming")
 @Serializable
 internal enum class InstrumentationType {
-    Histogram, IncrementCounter
+    histogram, incrementCounter
 }
 

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebView.kt
@@ -43,7 +43,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
 import com.shopify.checkoutkit.CheckoutBridge.Companion.userAgentSuffix
-import com.shopify.checkoutkit.InstrumentationType.Histogram
+import com.shopify.checkoutkit.InstrumentationType.histogram
 import java.net.HttpURLConnection.HTTP_GONE
 import java.net.HttpURLConnection.HTTP_INTERNAL_ERROR
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
@@ -121,7 +121,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
             loadComplete = true
             val timeToLoad = System.currentTimeMillis() - initLoadTime
             CheckoutBridge.instrument(view!!, InstrumentationPayload(
-                "checkout_finished_loading", timeToLoad, Histogram, mapOf()
+                "checkout_finished_loading", timeToLoad, histogram, mapOf()
             ))
             checkoutBridge.getEventProcessor().onCheckoutViewLoadComplete()
         }

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebView.kt
@@ -43,7 +43,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
 import com.shopify.checkoutkit.CheckoutBridge.Companion.userAgentSuffix
-import com.shopify.checkoutkit.InstrumentationType.histogram
+import com.shopify.checkoutkit.InstrumentationType.Histogram
 import java.net.HttpURLConnection.HTTP_GONE
 import java.net.HttpURLConnection.HTTP_INTERNAL_ERROR
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
@@ -121,7 +121,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
             loadComplete = true
             val timeToLoad = System.currentTimeMillis() - initLoadTime
             CheckoutBridge.instrument(view!!, InstrumentationPayload(
-                "checkout_finished_loading", timeToLoad, histogram, mapOf()
+                "checkout_finished_loading", timeToLoad, Histogram, mapOf()
             ))
             checkoutBridge.getEventProcessor().onCheckoutViewLoadComplete()
         }

--- a/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
@@ -74,7 +74,7 @@ class CheckoutBridgeSdkEventsTest {
         )
         val expectedPayload = """{"detail":{"name":"Test","value":123,"type":"histogram","tags":{"tag1":"value1","tag2":"value2"}}}"""
         val expectedJavascript = "window.MobileCheckoutSdk.dispatchMessage('instrumentation', ${expectedPayload})"
-        val timeoutEncapsulatedExpectation = "setTimeout(()=> {${expectedJavascript}; }, 2000)"
+        val timeoutEncapsulatedExpectation = "setTimeout(()=> {${expectedJavascript}; }, 1000)"
 
         CheckoutBridge.instrument(webView, payload)
         verify(webView).evaluateJavascript(timeoutEncapsulatedExpectation, null)

--- a/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
@@ -69,7 +69,7 @@ class CheckoutBridgeSdkEventsTest {
         val payload = InstrumentationPayload(
             name = "Test",
             value = 123L,
-            type = InstrumentationType.Histogram,
+            type = InstrumentationType.histogram,
             tags = mapOf("tag1" to "value1", "tag2" to "value2")
         )
         val expectedPayload = """{"detail":{"name":"Test","value":123,"type":"histogram","tags":{"tag1":"value1","tag2":"value2"}}}"""

--- a/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
@@ -22,41 +22,61 @@
  */
 package com.shopify.checkoutkit
 
+import android.webkit.WebView
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
-class CheckoutBridgeMetadataTest {
+class CheckoutBridgeSdkEventsTest {
 
     @Test
     fun `user agent suffix includes ShopifyCheckoutSDK and version number`() {
         ShopifyCheckoutKit.configuration.colorScheme = ColorScheme.Dark()
-        assertThat(CheckoutBridgeMetadata.userAgentSuffix()).startsWith("ShopifyCheckoutSDK/${BuildConfig.SDK_VERSION} ")
+        assertThat(CheckoutBridge.userAgentSuffix()).startsWith("ShopifyCheckoutSDK/${BuildConfig.SDK_VERSION} ")
     }
 
     @Test
     fun `user agent suffix includes metadata for the schema version, theme, and variant - dark`() {
         ShopifyCheckoutKit.configuration.colorScheme = ColorScheme.Dark()
-        assertThat(CheckoutBridgeMetadata.userAgentSuffix()).endsWith("(5.3;dark;standard)")
+        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(6.0;dark;standard)")
     }
 
     @Test
     fun `user agent suffix includes metadata for the schema version, theme, and variant - light`() {
         ShopifyCheckoutKit.configuration.colorScheme = ColorScheme.Light()
-        assertThat(CheckoutBridgeMetadata.userAgentSuffix()).endsWith("(5.3;light;standard)")
+        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(6.0;light;standard)")
     }
 
     @Test
     fun `user agent suffix includes metadata for the schema version, theme, and variant - web`() {
         ShopifyCheckoutKit.configuration.colorScheme = ColorScheme.Web()
-        assertThat(CheckoutBridgeMetadata.userAgentSuffix()).endsWith("(5.3;web_default;standard)")
+        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(6.0;web_default;standard)")
     }
 
     @Test
     fun `user agent suffix includes metadata for the schema version, theme, and variant - automatic`() {
         ShopifyCheckoutKit.configuration.colorScheme = ColorScheme.Automatic()
-        assertThat(CheckoutBridgeMetadata.userAgentSuffix()).endsWith("(5.3;automatic;standard)")
+        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(6.0;automatic;standard)")
+    }
+
+    @Test
+    fun `instrumentation sends message to the bridge`() {
+        val webView = Mockito.mock(WebView::class.java)
+        val payload = InstrumentationPayload(
+            name = "Test",
+            value = 123L,
+            type = InstrumentationType.histogram,
+            tags = mapOf("tag1" to "value1", "tag2" to "value2")
+        )
+        val expectedPayload = """{"detail":{"name":"Test","value":123,"type":"histogram","tags":{"tag1":"value1","tag2":"value2"}}}"""
+        val expectedJavascript = "window.MobileCheckoutSdk.dispatchMessage('instrumentation', ${expectedPayload})"
+        val timeoutEncapsulatedExpectation = "setTimeout(()=> {${expectedJavascript}; }, 2000)"
+
+        CheckoutBridge.instrument(webView, payload)
+        verify(webView).evaluateJavascript(timeoutEncapsulatedExpectation, null)
     }
 }

--- a/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeSdkEventsTest.kt
@@ -69,7 +69,7 @@ class CheckoutBridgeSdkEventsTest {
         val payload = InstrumentationPayload(
             name = "Test",
             value = 123L,
-            type = InstrumentationType.histogram,
+            type = InstrumentationType.Histogram,
             tags = mapOf("tag1" to "value1", "tag2" to "value2")
         )
         val expectedPayload = """{"detail":{"name":"Test","value":123,"type":"histogram","tags":{"tag1":"value1","tag2":"value2"}}}"""


### PR DESCRIPTION
### What are you trying to accomplish?

Adds instrumentation events from sdk->web. Focus is on adding the core eventing system now, only adding one metric for the moment

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
