### PR TITLE
add tests for default checkout event processor

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
@@ -114,14 +114,17 @@ internal class NoopEventProcessor : CheckoutEventProcessor {
  * for handling checkout events and interacting with the Android operating system.
  * @param context from which we will launch intents.
  */
-public abstract class DefaultCheckoutEventProcessor(private val context: Context) : CheckoutEventProcessor {
+public abstract class DefaultCheckoutEventProcessor(
+    private val context: Context,
+    private val log: LogWrapper = LogWrapper(),
+) : CheckoutEventProcessor {
 
     override fun onCheckoutLinkClicked(uri: Uri) {
         when (uri.scheme) {
             "tel" -> context.launchPhoneApp(uri.schemeSpecificPart)
             "mailto" -> context.launchEmailApp(uri.schemeSpecificPart)
             "https", "http" -> context.launchBrowser(uri)
-            else -> println("Unrecognized scheme for uri $uri")
+            else -> log.w(TAG, "Unrecognized scheme for link clicked in checkout '$uri'")
         }
     }
 
@@ -141,5 +144,9 @@ public abstract class DefaultCheckoutEventProcessor(private val context: Context
     private fun Context.launchPhoneApp(phone: String) {
         val intent = Intent(Intent.ACTION_DIAL, Uri.fromParts("tel", phone, null))
         startActivity(intent)
+    }
+
+    private companion object {
+        private const val TAG = "DefaultCheckoutEventProcessor"
     }
 }

--- a/lib/src/main/java/com/shopify/checkoutkit/LogWrapper.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/LogWrapper.kt
@@ -1,3 +1,25 @@
+/*
+ * MIT License
+ * 
+ * Copyright 2023-present, Shopify Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.shopify.checkoutkit
 
 import android.util.Log

--- a/lib/src/main/java/com/shopify/checkoutkit/LogWrapper.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/LogWrapper.kt
@@ -1,0 +1,16 @@
+package com.shopify.checkoutkit
+
+import android.util.Log
+
+/**
+ * Wrap Log class static methods to allow testing
+ */
+public class LogWrapper {
+    public fun w(tag: String, msg: String) {
+        Log.w(tag, msg)
+    }
+
+    public fun e(tag: String, msg: String) {
+        Log.e(tag, msg)
+    }
+}

--- a/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
@@ -1,0 +1,89 @@
+package com.shopify.checkoutkit
+
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowActivity
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultCheckoutEventProcessorTest {
+
+    private lateinit var activity: ComponentActivity
+    private lateinit var shadowActivity: ShadowActivity
+
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(ComponentActivity::class.java).get()
+        shadowActivity = shadowOf(activity)
+    }
+
+    @Test
+    fun `onCheckoutLinkClicked with http scheme launches action view intent with uri as data`() {
+        val processor = processor(activity)
+        val uri = Uri.parse("https://shopify.com")
+
+        processor.onCheckoutLinkClicked(uri)
+
+        val intent = shadowActivity.peekNextStartedActivityForResult().intent
+        assertThat(intent.data).isEqualTo(uri)
+        intent.type = Intent.ACTION_VIEW
+    }
+
+    @Test
+    fun `onCheckoutLinkClicked with mailto scheme launches email intent with to address`() {
+        val processor = processor(activity)
+        val uri = Uri.parse("mailto:test.user@shopify.com")
+
+        processor.onCheckoutLinkClicked(uri)
+
+        val intent = shadowActivity.peekNextStartedActivityForResult().intent
+        assertThat(intent.getStringArrayExtra(Intent.EXTRA_EMAIL)).isEqualTo(arrayOf("test.user@shopify.com"))
+        intent.type = "vnd.android.cursor.item/email"
+    }
+
+    @Test
+    fun `onCheckoutLinkClicked with tel scheme launches action dial intent with phone number`() {
+        val processor = processor(activity)
+        val uri = Uri.parse("tel:0123456789")
+
+        processor.onCheckoutLinkClicked(uri)
+
+        val intent = shadowActivity.peekNextStartedActivityForResult().intent
+        assertThat(intent.data).isEqualTo(uri)
+        intent.type =  Intent.ACTION_DIAL
+    }
+
+    @Test
+    fun `onCheckoutLinkedClick with unhandled scheme logs warning`() {
+        val log = mock<LogWrapper>()
+        val processor = object: DefaultCheckoutEventProcessor(activity, log) {
+            override fun onCheckoutCompleted() {/* not implemented */}
+            override fun onCheckoutFailed(error: CheckoutException) {/* not implemented */}
+            override fun onCheckoutCanceled() {/* not implemented */}
+        }
+
+        val uri = Uri.parse("ftp:lsklsm")
+
+        processor.onCheckoutLinkClicked(uri)
+
+        assertThat(shadowActivity.peekNextStartedActivityForResult()).isNull()
+        verify(log).w("DefaultCheckoutEventProcessor", "Unrecognized scheme for link clicked in checkout 'ftp:lsklsm'")
+    }
+
+    private fun processor(activity: ComponentActivity): DefaultCheckoutEventProcessor {
+        return object: DefaultCheckoutEventProcessor(activity) {
+            override fun onCheckoutCompleted() {/* not implemented */}
+            override fun onCheckoutFailed(error: CheckoutException) {/* not implemented */}
+            override fun onCheckoutCanceled() {/* not implemented */}
+        }
+    }
+}

--- a/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
@@ -1,3 +1,25 @@
+/*
+ * MIT License
+ * 
+ * Copyright 2023-present, Shopify Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.shopify.checkoutkit
 
 import android.content.Intent


### PR DESCRIPTION
### What are you trying to accomplish?

Updates DefaultCheckoutEventProcessor
1. Replaces the println() call with a `Log.w()` call
2. Adds tests 
3. Adds a LogWrapper to allow asserting on log messages

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
