### PR TITLE
java interop and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,26 @@ ShopifyCheckoutKit.configure {
 }
 ```
 
-_Note: Colors can also be specified in sRGB format (e.g. `Color.SRGB(-0xff0001)`)_
+- _Note: use preloading to optimize and deliver an instant buyer experience._
+- _Note: Colors can also be specified in sRGB format (e.g. `Color.SRGB(-0xff0001)`)_
+- _Note: Colors can also be overridden for Light/Dark/Automatic themes, e.g:_
 
-_Note: use preloading to optimize and deliver an instant buyer experience._
+```kotlin
+val automatic = ColorScheme.Automatic(
+    lightColors = Colors(
+        headerBackground = Color.ResourceId(R.color.headerLight),
+        headerFont = Color.ResourceId(R.color.headerFontLight),
+        webViewBackground = Color.ResourceId(R.color.webViewBgLight),
+        spinnerColor = Color.ResourceId(R.color.spinnerLight),
+    ),
+    darkColors = Colors(
+        headerBackground = Color.ResourceId(R.color.headerDark),
+        headerFont = Color.ResourceId(R.color.headerFontDark,
+        webViewBackground = Color.ResourceId(R.color.webViewBgDark),
+        spinnerColor = Color.ResourceId(R.color.spinnerDark),
+    )
+)
+```
 
 The current configuration can be obtained by calling `ShopifyCheckoutKit.getConfiguration()`.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ your project:
 #### Gradle
 
 ```groovy
-implementation "com.shopify.checkout:checkout-kit:$checkoutSdkVersion"
+implementation "com.shopify:checkout-kit:$checkoutSdkVersion"
 ```
 
 #### Maven

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
@@ -114,7 +114,7 @@ internal class NoopEventProcessor : CheckoutEventProcessor {
  * for handling checkout events and interacting with the Android operating system.
  * @param context from which we will launch intents.
  */
-public abstract class DefaultCheckoutEventProcessor(
+public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
     private val context: Context,
     private val log: LogWrapper = LogWrapper(),
 ) : CheckoutEventProcessor {

--- a/lib/src/test/java/com/shopify/checkoutkit/InteropTest.java
+++ b/lib/src/test/java/com/shopify/checkoutkit/InteropTest.java
@@ -1,0 +1,47 @@
+package com.shopify.checkoutkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.app.Activity;
+
+import androidx.activity.ComponentActivity;
+import androidx.annotation.NonNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class InteropTest {
+
+    private Activity activity = null;
+
+    @Before
+    public void setUp() {
+        activity = Robolectric.buildActivity(ComponentActivity.class).get();
+    }
+
+    @Test
+    public void canInstantiateCustomEventProcessorWithDefaultArg() {
+        DefaultCheckoutEventProcessor processor = new DefaultCheckoutEventProcessor(activity) {
+            @Override
+            public void onCheckoutCompleted() {
+
+            }
+
+            @Override
+            public void onCheckoutFailed(@NonNull CheckoutException error) {
+
+            }
+
+            @Override
+            public void onCheckoutCanceled() {
+
+            }
+        };
+
+        assertThat(processor).isNotNull();
+    }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

- Add missing JvmOverloads annotation to `DefaultCheckoutEventProcessor` and add an initial interop test to allow catching issues and regressions around java interop
- Correct the group name in the gradle readme example
- Add readme example of overriding automatic colors

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
