### PR TITLE
Expose the errorDescription var on the CheckoutException class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,7 @@ after release for General Availability.
 
 - Adds annotations (`@ColorInt` and `@ColorRes`) for more robust color value enforcement.
 - Exposes the `lightColors` and `darkColors` properties of the `Automatic` ColorScheme class to allow overrides.
+
+## 0.3.3 - November 27, 2023
+
+- Exposes the `errorDescription` internal variable on the `CheckoutException` class.

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_KIT_VERSION", "0.3.2")
+def versionName = resolveEnvVarValue("CHECKOUT_KIT_VERSION", "0.3.3")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.Serializable
  * Superclass for the Shopify Checkout Kit exceptions
  */
 @Serializable
-public abstract class CheckoutException(private val errorDescription: String) : Exception(errorDescription)
+public abstract class CheckoutException(public val errorDescription: String) : Exception(errorDescription)
 
 /**
  * Issued when an internal error occurs within Shopify Checkout Kit.

--- a/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
@@ -101,6 +101,30 @@ class DefaultCheckoutEventProcessorTest {
         verify(log).w("DefaultCheckoutEventProcessor", "Unrecognized scheme for link clicked in checkout 'ftp:lsklsm'")
     }
 
+    @Test
+    fun `onCheckoutFailed returns an error description`() {
+        val log = mock<LogWrapper>()
+        var description = ""
+        val processor =
+                object : DefaultCheckoutEventProcessor(activity, log) {
+                    override fun onCheckoutCompleted() {
+                        /* not implemented */
+                    }
+                    override fun onCheckoutFailed(error: CheckoutException) {
+                        description = error.errorDescription
+                    }
+                    override fun onCheckoutCanceled() {
+                        /* not implemented */
+                    }
+                }
+
+        val error = object : CheckoutException("error description") {}
+
+        processor.onCheckoutFailed(error)
+
+        assertThat(description).isEqualTo("error description")
+    }
+
     private fun processor(activity: ComponentActivity): DefaultCheckoutEventProcessor {
         return object: DefaultCheckoutEventProcessor(activity) {
             override fun onCheckoutCompleted() {/* not implemented */}


### PR DESCRIPTION
### What are you trying to accomplish?

Expose the errorDescription var on the CheckoutException class

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
