### PR TITLE
enable preloading by default

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/Configuration.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/Configuration.kt
@@ -40,5 +40,5 @@ public data class Configuration internal constructor(
  * Initially allows toggling the preloading feature.
  */
 public data class Preloading(
-    val enabled: Boolean = false
+    val enabled: Boolean = true
 )

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -31,6 +31,7 @@ import androidx.activity.ComponentActivity
 import androidx.appcompat.widget.Toolbar
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,7 +49,17 @@ class CheckoutDialogTest {
 
     @Before
     fun setUp() {
+        ShopifyCheckoutKit.configure {
+            it.preloading = Preloading(enabled = false)
+        }
         activity = Robolectric.buildActivity(ComponentActivity::class.java).get()
+    }
+
+    @After
+    fun tearDown() {
+        ShopifyCheckoutKit.configure {
+            it.preloading = Preloading(enabled = true)
+        }
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -49,7 +49,7 @@ class CheckoutDialogTest {
 
     @Before
     fun setUp() {
-        ShopifyCheckoutKit.configure {
+        ShopifyCheckoutSheet.configure {
             it.preloading = Preloading(enabled = false)
         }
         activity = Robolectric.buildActivity(ComponentActivity::class.java).get()
@@ -57,7 +57,7 @@ class CheckoutDialogTest {
 
     @After
     fun tearDown() {
-        ShopifyCheckoutKit.configure {
+        ShopifyCheckoutSheet.configure {
             it.preloading = Preloading(enabled = true)
         }
     }


### PR DESCRIPTION
### What are you trying to accomplish?

Enable preloading by default

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
