### PR TITLE
rework how messages are sent to web

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebView.kt
@@ -55,10 +55,7 @@ import kotlin.time.Duration.Companion.minutes
 internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = null) :
     WebView(context, attributeSet) {
 
-    private val checkoutBridge = CheckoutBridge(
-        this,
-        CheckoutWebViewEventProcessor(NoopEventProcessor())
-    )
+    private val checkoutBridge = CheckoutBridge(CheckoutWebViewEventProcessor(NoopEventProcessor()))
     private var loadComplete = false
     private var initLoadTime: Long = -1
 
@@ -73,7 +70,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
     }
 
     fun notifyPresented() {
-        checkoutBridge.sendMessage(CheckoutBridge.SDKOperation.PRESENTED)
+        checkoutBridge.sendMessage(this, CheckoutBridge.SDKOperation.Presented)
     }
 
     private fun configureWebView() {
@@ -123,12 +120,14 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
             }
         }
 
-        override fun onPageFinished(view: WebView?, url: String?) {
+        override fun onPageFinished(view: WebView, url: String) {
             super.onPageFinished(view, url)
             loadComplete = true
             val timeToLoad = System.currentTimeMillis() - initLoadTime
-            CheckoutBridge.instrument(view!!, InstrumentationPayload(
-                "checkout_finished_loading", timeToLoad, histogram, mapOf()
+            checkoutBridge.sendMessage(view, CheckoutBridge.SDKOperation.Instrumentation(
+                InstrumentationPayload(
+                    "checkout_finished_loading", timeToLoad, histogram, mapOf()
+                )
             ))
             checkoutBridge.getEventProcessor().onCheckoutViewLoadComplete()
         }


### PR DESCRIPTION
### What are you trying to accomplish?

Rework how events are sent to web.

Instead of waiting for the init event from web, and draining a buffered queue of messages, we'll send messages by adding an event listener for a new event we'll emit in web when the bridge is ready, and send the message in the callback

This simplifies the code, and removes the need for parsing the init event, which preloading can cause issues with.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
