### PR TITLE
receive analytics events and proxy to client via onAnalyticsEvent

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
@@ -138,6 +138,10 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
         }
     }
 
+    override fun onAnalyticsEvent(analyticsEvent: AnalyticsEvent) {
+        // no-op, override to implement
+    }
+
     private fun Context.launchEmailApp(to: String) {
         val intent = Intent(Intent.ACTION_SEND)
         intent.type = "vnd.android.cursor.item/email"

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutEventProcessor.kt
@@ -25,6 +25,7 @@ package com.shopify.checkoutkit
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import com.shopify.checkoutkit.messages.AnalyticsEvent
 import kotlinx.serialization.Serializable
 
 /**
@@ -93,6 +94,12 @@ public interface CheckoutEventProcessor {
      * of the WebView, e.g. in a system browser or email client. Protocols can be http/https/mailto/tel
      */
     public fun onCheckoutLinkClicked(uri: Uri)
+
+    /**
+     * Event with analytics data that can be optionally transformed, enhanced (e.g. with user and session identifiers),
+     * and forwarded on to an analytics service
+     */
+    public fun onAnalyticsEvent(analyticsEvent: AnalyticsEvent)
 }
 
 internal class NoopEventProcessor : CheckoutEventProcessor {
@@ -106,6 +113,9 @@ internal class NoopEventProcessor : CheckoutEventProcessor {
     }
 
     override fun onCheckoutLinkClicked(uri: Uri) {/* noop */
+    }
+
+    override fun onAnalyticsEvent(analyticsEvent: AnalyticsEvent) {/* noop */
     }
 }
 

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutWebViewEventProcessor.kt
@@ -25,6 +25,7 @@ package com.shopify.checkoutkit
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import com.shopify.checkoutkit.messages.AnalyticsEvent
 
 /**
  * Event processor that can handle events internally, delegate to the CheckoutEventProcessor
@@ -61,6 +62,10 @@ internal class CheckoutWebViewEventProcessor(
         onMainThread {
             hideProgressBar()
         }
+    }
+
+    fun onAnalyticsEvent(event: AnalyticsEvent) {
+        eventProcessor.onAnalyticsEvent(event)
     }
 
     private fun onMainThread(block: () -> Unit) {

--- a/lib/src/main/java/com/shopify/checkoutkit/LogWrapper.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/LogWrapper.kt
@@ -35,4 +35,8 @@ public class LogWrapper {
     public fun e(tag: String, msg: String) {
         Log.e(tag, msg)
     }
+
+    public fun e(tag: String, msg: String, throwable: Throwable) {
+        Log.e(tag, msg, throwable)
+    }
 }

--- a/lib/src/main/java/com/shopify/checkoutkit/messages/Analytics.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/messages/Analytics.kt
@@ -1,0 +1,1326 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutkit.messages
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+internal class RawAnalyticsEvent(
+    internal val name: String,
+    internal val event: JsonObject,
+)
+
+public interface AnalyticsEvent {
+    /**
+     * The ID of the customer event
+     */
+    public val id: String?
+
+    /**
+     * The name of the customer event
+     */
+    public val name: String?
+
+    /**
+     * The timestamp of when the customer event occurred, in [ISO
+     * 8601](https://en.wikipedia.org/wiki/ISO_8601) format
+     */
+    public val timestamp: String?
+
+    public val context: Context?
+}
+
+public enum class AnalyticsEventType(public val eventName: String) {
+    CART_VIEWED("cart_viewed"),
+    CHECKOUT_ADDRESS_INFO_SUBMITTED("checkout_address_info_submitted"),
+    CHECKOUT_COMPLETED("checkout_completed"),
+    CHECKOUT_CONTACT_INFO_SUBMITTED("checkout_contact_info_submitted"),
+    CHECKOUT_SHIPPING_INFO_SUBMITTED("checkout_shipping_info_submitted"),
+    CHECKOUT_STARTED("checkout_started"),
+    COLLECTION_VIEWED("collection_viewed"),
+    PAGE_VIEWED("page_viewed"),
+    PAYMENT_INFO_SUBMITTED("payment_info_submitted"),
+    PRODUCT_ADDED_TO_CART("product_added_to_cart"),
+    PRODUCT_REMOVED_FROM_CART("product_removed_from_cart"),
+    PRODUCT_VIEWED("product_viewed"),
+    SEARCH_SUBMITTED("search_submitted");
+
+    public companion object {
+        public fun fromEventName(eventName: String): AnalyticsEventType? =
+            AnalyticsEventType.values().firstOrNull {
+                it.eventName == eventName
+            }
+    }
+}
+
+/**
+ * The `cart_viewed` event logs an instance where a customer visited the cart
+ * page
+ */
+@Serializable
+public data class CartViewed (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: CartViewedData? = null,
+): AnalyticsEvent
+
+/**
+ * A snapshot of various read-only properties of the browser at the time of
+ * event
+ */
+@Serializable
+public data class Context (
+    /**
+     * Snapshot of a subset of properties of the `document` object in the top
+     * frame of the browser
+     */
+    public val document: WebPixelsDocument? = null,
+
+    /**
+     * Snapshot of a subset of properties of the `navigator` object in the top
+     * frame of the browser
+     */
+    public val navigator: WebPixelsNavigator? = null,
+
+    /**
+     * Snapshot of a subset of properties of the `window` object in the top frame
+     * of the browser
+     */
+    public val window: WebPixelsWindow? = null
+)
+
+/**
+ * Snapshot of a subset of properties of the `document` object in the top
+ * frame of the browser
+ *
+ * A snapshot of a subset of properties of the `document` object in the top
+ * frame of the browser
+ */
+@Serializable
+public data class WebPixelsDocument (
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
+     * returns the character set being used by the document
+     */
+    public val characterSet: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
+     * returns the URI of the current document
+     */
+    public val location: Location? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
+     * returns the URI of the page that linked to this page
+     */
+    public val referrer: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
+     * returns the title of the current document
+     */
+    public val title: String? = null
+)
+
+/**
+ * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
+ * returns the URI of the current document
+ *
+ * A snapshot of a subset of properties of the `location` object in the top
+ * frame of the browser
+ *
+ * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
+ * location, or current URL, of the window object
+ */
+@Serializable
+public data class Location (
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing a `'#'` followed by the fragment identifier of the URL
+     */
+    public val hash: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing the host, that is the hostname, a `':'`, and the port of
+     * the URL
+     */
+    public val host: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing the domain of the URL
+     */
+    public val hostname: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing the entire URL
+     */
+    public val href: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing the canonical form of the origin of the specific location
+     */
+    public val origin: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing an initial `'/'` followed by the path of the URL, not
+     * including the query string or fragment
+     */
+    public val pathname: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing the port number of the URL
+     */
+    public val port: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing the protocol scheme of the URL, including the final `':'`
+     */
+    public val protocol: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
+     * string containing a `'?'` followed by the parameters or "querystring" of
+     * the URL
+     */
+    public val search: String? = null
+)
+
+/**
+ * Snapshot of a subset of properties of the `navigator` object in the top
+ * frame of the browser
+ *
+ * A snapshot of a subset of properties of the `navigator` object in the top
+ * frame of the browser
+ */
+@Serializable
+public data class WebPixelsNavigator (
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
+     * returns `false` if setting a cookie will be ignored and true otherwise
+     */
+    public val cookieEnabled: Boolean? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
+     * returns a string representing the preferred language of the user, usually
+     * the language of the browser UI. The `null` value is returned when this
+     * is unknown
+     */
+    public val language: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
+     * returns an array of strings representing the languages known to the user,
+     * by order of preference
+     */
+    public val languages: List<String>? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
+     * returns the user agent string for the current browser
+     */
+    public val userAgent: String? = null
+)
+
+/**
+ * Snapshot of a subset of properties of the `window` object in the top frame
+ * of the browser
+ *
+ * A snapshot of a subset of properties of the `window` object in the top frame
+ * of the browser
+ */
+@Serializable
+public data class WebPixelsWindow (
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window),
+     * gets the height of the content area of the browser window including, if
+     * rendered, the horizontal scrollbar
+     */
+    public val innerHeight: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), gets
+     * the width of the content area of the browser window including, if rendered,
+     * the vertical scrollbar
+     */
+    public val innerWidth: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
+     * location, or current URL, of the window object
+     */
+    public val location: Location? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
+     * global object's origin, serialized as a string
+     */
+    public val origin: String? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), gets
+     * the height of the outside of the browser window
+     */
+    public val outerHeight: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), gets
+     * the width of the outside of the browser window
+     */
+    public val outerWidth: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), an
+     * alias for window.scrollX
+     */
+    public val pageXOffset: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), an
+     * alias for window.scrollY
+     */
+    public val pageYOffset: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen), the
+     * interface representing a screen, usually the one on which the current
+     * window is being rendered
+     */
+    public val screen: Screen? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
+     * horizontal distance from the left border of the user's browser viewport to
+     * the left side of the screen
+     */
+    public val screenX: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
+     * vertical distance from the top border of the user's browser viewport to the
+     * top side of the screen
+     */
+    public val screenY: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
+     * number of pixels that the document has already been scrolled horizontally
+     */
+    public val scrollX: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
+     * number of pixels that the document has already been scrolled vertically
+     */
+    public val scrollY: Double? = null
+)
+
+/**
+ * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen), the
+ * interface representing a screen, usually the one on which the current
+ * window is being rendered
+ *
+ * The interface representing a screen, usually the one on which the current
+ * window is being rendered
+ */
+@Serializable
+public data class Screen (
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/height),
+     * the height of the screen
+     */
+    public val height: Double? = null,
+
+    /**
+     * Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/width),
+     * the width of the screen
+     */
+    public val width: Double? = null
+)
+
+@Serializable
+public data class CartViewedData (
+    public val cart: Cart? = null
+)
+
+/**
+ * A cart represents the merchandise that a customer intends to purchase, and
+ * the estimated cost associated with the cart.
+ */
+@Serializable
+public data class Cart (
+    /**
+     * The estimated costs that the customer will pay at checkout.
+     */
+    public val cost: CartCost? = null,
+
+    /**
+     * A globally unique identifier.
+     */
+    public val id: String? = null,
+
+    public val lines: List<CartLine>? = null,
+
+    /**
+     * The total number of items in the cart.
+     */
+    public val totalQuantity: Double? = null
+)
+
+/**
+ * The estimated costs that the customer will pay at checkout.
+ *
+ * The costs that the customer will pay at checkout. It uses
+ * [`CartBuyerIdentity`](https://shopify.dev/api/storefront/reference/cart/cartb
+ * uyeridentity) to determine [international pricing](https://shopify.dev/custom-
+ * storefronts/internationalization/international-pricing#create-a-cart).
+ */
+@Serializable
+public data class CartCost (
+    /**
+     * The total amount for the customer to pay.
+     */
+    public val totalAmount: MoneyV2? = null
+)
+
+/**
+ * The total amount for the customer to pay.
+ *
+ * A monetary value with currency.
+ *
+ * The total cost of the merchandise line.
+ *
+ * The product variant’s price.
+ *
+ * The monetary value with currency allocated to the discount.
+ *
+ * Price of this shipping rate.
+ *
+ * The price at checkout before duties, shipping, and taxes.
+ *
+ * The sum of all the prices of all the items in the checkout, including
+ * duties, taxes, and discounts.
+ *
+ * The sum of all the taxes applied to the line items and shipping lines in
+ * the checkout.
+ *
+ * The monetary value with currency allocated to the transaction method.
+ */
+@Serializable
+public data class MoneyV2 (
+    /**
+     * The decimal money amount.
+     */
+    public val amount: Double? = null,
+
+    /**
+     * The three-letter code that represents the currency, for example, USD.
+     * Supported codes include standard ISO 4217 codes, legacy codes, and non-
+     * standard codes.
+     */
+    public val currencyCode: String? = null
+)
+
+/**
+ * Information about the merchandise in the cart.
+ */
+@Serializable
+public data class CartLine (
+    /**
+     * The cost of the merchandise that the customer will pay for at checkout. The
+     * costs are subject to change and changes will be reflected at checkout.
+     */
+    public val cost: CartLineCost? = null,
+
+    /**
+     * The merchandise that the buyer intends to purchase.
+     */
+    public val merchandise: ProductVariant? = null,
+
+    /**
+     * The quantity of the merchandise that the customer intends to purchase.
+     */
+    public val quantity: Double? = null
+)
+
+/**
+ * The cost of the merchandise that the customer will pay for at checkout. The
+ * costs are subject to change and changes will be reflected at checkout.
+ *
+ * The cost of the merchandise line that the customer will pay at checkout.
+ */
+@Serializable
+public data class CartLineCost (
+    /**
+     * The total cost of the merchandise line.
+     */
+    public val totalAmount: MoneyV2? = null
+)
+
+/**
+ * The merchandise that the buyer intends to purchase.
+ *
+ * A product variant represents a different version of a product, such as
+ * differing sizes or differing colors.
+ */
+@Serializable
+public data class ProductVariant (
+    /**
+     * A globally unique identifier.
+     */
+    public val id: String? = null,
+
+    /**
+     * Image associated with the product variant. This field falls back to the
+     * product image if no image is available.
+     */
+    public val image: Image? = null,
+
+    /**
+     * The product variant’s price.
+     */
+    public val price: MoneyV2? = null,
+
+    /**
+     * The product object that the product variant belongs to.
+     */
+    public val product: Product? = null,
+
+    /**
+     * The SKU (stock keeping unit) associated with the variant.
+     */
+    public val sku: String? = null,
+
+    /**
+     * The product variant’s title.
+     */
+    public val title: String? = null,
+
+    /**
+     * The product variant’s untranslated title.
+     */
+    public val untranslatedTitle: String? = null
+)
+
+/**
+ * An image resource.
+ */
+@Serializable
+public data class Image (
+    /**
+     * The location of the image as a URL.
+     */
+    public val src: String? = null
+)
+
+/**
+ * The product object that the product variant belongs to.
+ *
+ * A product is an individual item for sale in a Shopify store.
+ */
+@Serializable
+public data class Product (
+    /**
+     * The ID of the product.
+     */
+    public val id: String? = null,
+
+    /**
+     * The product’s title.
+     */
+    public val title: String? = null,
+
+    /**
+     * The [product
+     * type](https://help.shopify.com/en/manual/products/details/product-type)
+     * specified by the merchant.
+     */
+    public val type: String? = null,
+
+    /**
+     * The product’s untranslated title.
+     */
+    public val untranslatedTitle: String? = null,
+
+    /**
+     * The relative URL of the product.
+     */
+    public val url: String? = null,
+
+    /**
+     * The product’s vendor name.
+     */
+    public val vendor: String? = null
+)
+
+/**
+ * The `checkout_address_info_submitted` event logs an instance of a customer
+ * submitting their mailing address. This event is only available in checkouts
+ * where checkout extensibility for customizations is enabled
+ */
+@Serializable
+public data class CheckoutAddressInfoSubmitted (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: CheckoutAddressInfoSubmittedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class CheckoutAddressInfoSubmittedData (
+    public val checkout: Checkout? = null
+)
+
+/**
+ * A container for all the information required to add items to checkout and
+ * pay.
+ */
+@Serializable
+public data class Checkout (
+    /**
+     * A list of attributes accumulated throughout the checkout process.
+     */
+    public val attributes: List<Attribute>? = null,
+
+    /**
+     * The billing address to where the order will be charged.
+     */
+    public val billingAddress: MailingAddress? = null,
+
+    /**
+     * The three-letter code that represents the currency, for example, USD.
+     * Supported codes include standard ISO 4217 codes, legacy codes, and non-
+     * standard codes.
+     */
+    public val currencyCode: String? = null,
+
+    /**
+     * A list of discount applications.
+     */
+    public val discountApplications: List<DiscountApplication>? = null,
+
+    /**
+     * The email attached to this checkout.
+     */
+    public val email: String? = null,
+
+    /**
+     * A list of line item objects, each one containing information about an item
+     * in the checkout.
+     */
+    public val lineItems: List<CheckoutLineItem>? = null,
+
+    /**
+     * The resulting order from a paid checkout.
+     */
+    public val order: Order? = null,
+
+    /**
+     * A unique phone number for the customer. Formatted using E.164 standard. For
+     * example, *+16135551111*.
+     */
+    public val phone: String? = null,
+
+    /**
+     * The shipping address to where the line items will be shipped.
+     */
+    public val shippingAddress: MailingAddress? = null,
+
+    /**
+     * Once a shipping rate is selected by the customer it is transitioned to a
+     * `shipping_line` object.
+     */
+    public val shippingLine: ShippingRate? = null,
+
+    /**
+     * The price at checkout before duties, shipping, and taxes.
+     */
+    public val subtotalPrice: MoneyV2? = null,
+
+    /**
+     * A unique identifier for a particular checkout.
+     */
+    public val token: String? = null,
+
+    /**
+     * The sum of all the prices of all the items in the checkout, including
+     * duties, taxes, and discounts.
+     */
+    public val totalPrice: MoneyV2? = null,
+
+    /**
+     * The sum of all the taxes applied to the line items and shipping lines in
+     * the checkout.
+     */
+    public val totalTax: MoneyV2? = null,
+
+    /**
+     * A list of transactions associated with a checkout or order.
+     */
+    public val transactions: List<Transaction>? = null
+)
+
+/**
+ * Custom attributes left by the customer to the merchant, either in their cart
+ * or during checkout.
+ */
+@Serializable
+public data class Attribute (
+    /**
+     * The key for the attribute.
+     */
+    public val key: String? = null,
+
+    /**
+     * The value for the attribute.
+     */
+    public val value: String? = null
+)
+
+/**
+ * A mailing address for customers and shipping.
+ */
+@Serializable
+public data class MailingAddress (
+    /**
+     * The first line of the address. This is usually the street address or a P.O.
+     * Box number.
+     */
+    public val address1: String? = null,
+
+    /**
+     * The second line of the address. This is usually an apartment, suite, or
+     * unit number.
+     */
+    public val address2: String? = null,
+
+    /**
+     * The name of the city, district, village, or town.
+     */
+    public val city: String? = null,
+
+    /**
+     * The name of the country.
+     */
+    public val country: String? = null,
+
+    /**
+     * The two-letter code that represents the country, for example, US.
+     * The country codes generally follows ISO 3166-1 alpha-2 guidelines.
+     */
+    public val countryCode: String? = null,
+
+    /**
+     * The customer’s first name.
+     */
+    public val firstName: String? = null,
+
+    /**
+     * The customer’s last name.
+     */
+    public val lastName: String? = null,
+
+    /**
+     * The phone number for this mailing address as entered by the customer.
+     */
+    public val phone: String? = null,
+
+    /**
+     * The region of the address, such as the province, state, or district.
+     */
+    public val province: String? = null,
+
+    /**
+     * The two-letter code for the region.
+     * For example, ON.
+     */
+    public val provinceCode: String? = null,
+
+    /**
+     * The ZIP or postal code of the address.
+     */
+    public val zip: String? = null
+)
+
+/**
+ * The information about the intent of the discount.
+ */
+@Serializable
+public data class DiscountApplication (
+    /**
+     * The method by which the discount's value is applied to its entitled items.
+     *
+     * - `ACROSS`: The value is spread across all entitled lines.
+     * - `EACH`: The value is applied onto every entitled line.
+     */
+    public val allocationMethod: String? = null,
+
+    /**
+     * How the discount amount is distributed on the discounted lines.
+     *
+     * - `ALL`: The discount is allocated onto all the lines.
+     * - `ENTITLED`: The discount is allocated onto only the lines that it's
+     * entitled for.
+     * - `EXPLICIT`: The discount is allocated onto explicitly chosen lines.
+     */
+    public val targetSelection: String? = null,
+
+    /**
+     * The type of line (i.e. line item or shipping line) on an order that the
+     * discount is applicable towards.
+     *
+     * - `LINE_ITEM`: The discount applies onto line items.
+     * - `SHIPPING_LINE`: The discount applies onto shipping lines.
+     */
+    public val targetType: String? = null,
+
+    /**
+     * The customer-facing name of the discount. If the type of discount is
+     * a `DISCOUNT_CODE`, this `title` attribute represents the code of the
+     * discount.
+     */
+    public val title: String? = null,
+
+    /**
+     * The type of the discount.
+     *
+     * - `AUTOMATIC`: A discount automatically at checkout or in the cart without
+     * the need for a code.
+     * - `DISCOUNT_CODE`: A discount applied onto checkouts through the use of
+     * a code.
+     * - `MANUAL`: A discount that is applied to an order by a merchant or store
+     * owner manually, rather than being automatically applied by the system or
+     * through a script.
+     * - `SCRIPT`: A discount applied to a customer's order using a script
+     */
+    public val type: String? = null,
+
+    /**
+     * The value of the discount. Fixed discounts return a `Money` Object, while
+     * Percentage discounts return a `PricingPercentageValue` object.
+     */
+    public val value: Value? = null
+)
+
+/**
+ * The value of the discount. Fixed discounts return a `Money` Object, while
+ * Percentage discounts return a `PricingPercentageValue` object.
+ *
+ * The total amount for the customer to pay.
+ *
+ * A monetary value with currency.
+ *
+ * The total cost of the merchandise line.
+ *
+ * The product variant’s price.
+ *
+ * The monetary value with currency allocated to the discount.
+ *
+ * Price of this shipping rate.
+ *
+ * The price at checkout before duties, shipping, and taxes.
+ *
+ * The sum of all the prices of all the items in the checkout, including
+ * duties, taxes, and discounts.
+ *
+ * The sum of all the taxes applied to the line items and shipping lines in
+ * the checkout.
+ *
+ * The monetary value with currency allocated to the transaction method.
+ *
+ * A value given to a customer when a discount is applied to an order. The
+ * application of a discount with this value gives the customer the specified
+ * percentage off a specified item.
+ */
+@Serializable
+public data class Value (
+    /**
+     * The decimal money amount.
+     */
+    public val amount: Double? = null,
+
+    /**
+     * The three-letter code that represents the currency, for example, USD.
+     * Supported codes include standard ISO 4217 codes, legacy codes, and non-
+     * standard codes.
+     */
+    public val currencyCode: String? = null,
+
+    /**
+     * The percentage value of the object.
+     */
+    public val percentage: Double? = null
+)
+
+/**
+ * A single line item in the checkout, grouped by variant and attributes.
+ */
+@Serializable
+public data class CheckoutLineItem (
+    /**
+     * The discounts that have been applied to the checkout line item by a
+     * discount application.
+     */
+    public val discountAllocations: List<DiscountAllocation>? = null,
+
+    /**
+     * A globally unique identifier.
+     */
+    public val id: String? = null,
+
+    /**
+     * The quantity of the line item.
+     */
+    public val quantity: Double? = null,
+
+    /**
+     * The title of the line item. Defaults to the product's title.
+     */
+    public val title: String? = null,
+
+    /**
+     * Product variant of the line item.
+     */
+    public val variant: ProductVariant? = null
+)
+
+/**
+ * The discount that has been applied to the checkout line item.
+ */
+@Serializable
+public data class DiscountAllocation (
+    /**
+     * The monetary value with currency allocated to the discount.
+     */
+    public val amount: MoneyV2? = null,
+
+    /**
+     * The information about the intent of the discount.
+     */
+    public val discountApplication: DiscountApplication? = null
+)
+
+/**
+ * An order is a customer’s completed request to purchase one or more products
+ * from a shop. An order is created when a customer completes the checkout
+ * process.
+ */
+@Serializable
+public data class Order (
+    /**
+     * The ID of the order.
+     */
+    public val id: String? = null
+)
+
+/**
+ * A shipping rate to be applied to a checkout.
+ */
+@Serializable
+public data class ShippingRate (
+    /**
+     * Price of this shipping rate.
+     */
+    public val price: MoneyV2? = null
+)
+
+/**
+ * A transaction associated with a checkout or order.
+ */
+@Serializable
+public data class Transaction (
+    /**
+     * The monetary value with currency allocated to the transaction method.
+     */
+    public val amount: MoneyV2? = null,
+
+    /**
+     * The name of the payment provider used for the transaction.
+     */
+    public val gateway: String? = null
+)
+
+/**
+ * The `checkout_completed` event logs when a visitor completes a purchase. This
+ * event is available on the order status and checkout pages
+ *
+ * The `checkout_completed` event logs when a visitor completes a purchase.
+ * This event is available on the order status and checkout pages
+ */
+@Serializable
+public data class CheckoutCompleted (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: CheckoutCompletedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class CheckoutCompletedData (
+    public val checkout: Checkout? = null
+)
+
+/**
+ * The `checkout_contact_info_submitted` event logs an instance where a customer
+ * submits a checkout form. This event is only available in checkouts where
+ * checkout extensibility for customizations is enabled
+ *
+ * The `checkout_contact_info_submitted` event logs an instance where a
+ * customer submits a checkout form. This event is only available in checkouts
+ * where checkout extensibility for customizations is enabled
+ */
+@Serializable
+public data class CheckoutContactInfoSubmitted (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: CheckoutContactInfoSubmittedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class CheckoutContactInfoSubmittedData (
+    public val checkout: Checkout? = null
+)
+
+/**
+ * The `checkout_shipping_info_submitted` event logs an instance where the
+ * customer chooses a shipping rate. This event is only available in checkouts
+ * where checkout extensibility for customizations is enabled
+ */
+@Serializable
+public data class CheckoutShippingInfoSubmitted (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: CheckoutShippingInfoSubmittedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class CheckoutShippingInfoSubmittedData (
+    public val checkout: Checkout? = null
+)
+
+/**
+ * The `checkout_started` event logs an instance of a customer starting the
+ * checkout process. This event is available on the checkout page. For checkout
+ * extensibility, this event is triggered every time a customer enters checkout.
+ * For non-checkout extensible shops, this event is only triggered the first
+ * time a customer enters checkout.
+ *
+ * The `checkout_started` event logs an instance of a customer starting
+ * the checkout process. This event is available on the checkout page. For
+ * checkout extensibility, this event is triggered every time a customer
+ * enters checkout. For non-checkout extensible shops, this event is only
+ * triggered the first time a customer enters checkout.
+ */
+@Serializable
+public data class CheckoutStarted (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: CheckoutStartedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class CheckoutStartedData (
+    public val checkout: Checkout? = null
+)
+
+/**
+ * The `collection_viewed` event logs an instance where a customer visited a
+ * product collection index page. This event is available on the online store
+ * page
+ */
+@Serializable
+public data class CollectionViewed (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: CollectionViewedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class CollectionViewedData (
+    public val collection: Collection? = null
+)
+
+/**
+ * A collection is a group of products that a shop owner can create to organize
+ * them or make their shops easier to browse.
+ */
+@Serializable
+public data class Collection (
+    /**
+     * A globally unique identifier.
+     */
+    public val id: String? = null,
+
+    public val productVariants: List<ProductVariant>? = null,
+
+    /**
+     * The collection’s name. Maximum length: 255 characters.
+     */
+    public val title: String? = null
+)
+
+/**
+ * The `page_viewed` event logs an instance where a customer visited a page.
+ * This event is available on the online store, checkout, and order status pages
+ *
+ * The `page_viewed` event logs an instance where a customer visited a page.
+ * This event is available on the online store, checkout, and order status
+ * pages
+ */
+@Serializable
+public data class PageViewed (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: PageViewedData? = null,
+): AnalyticsEvent
+
+public typealias PageViewedData = JsonObject
+
+/**
+ * The `payment_info_submitted` event logs an instance of a customer submitting
+ * their payment information. This event is available on the checkout page
+ *
+ * The `payment_info_submitted` event logs an instance of a customer
+ * submitting their payment information. This event is available on the
+ * checkout page
+ */
+@Serializable
+public data class PaymentInfoSubmitted (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: PaymentInfoSubmittedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class PaymentInfoSubmittedData (
+    public val checkout: Checkout? = null
+)
+
+/**
+ * The `product_added_to_cart` event logs an instance where a customer adds a
+ * product to their cart. This event is available on the online store page
+ */
+@Serializable
+public data class ProductAddedToCart (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: ProductAddedToCartData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class ProductAddedToCartData (
+    public val cartLine: CartLine? = null
+)
+
+/**
+ * The `product_removed_from_cart` event logs an instance where a customer
+ * removes a product from their cart. This event is available on the online
+ * store page
+ */
+@Serializable
+public data class ProductRemovedFromCart (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: ProductRemovedFromCartData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class ProductRemovedFromCartData (
+    public val cartLine: CartLine? = null
+)
+
+/**
+ * The `product_variant_viewed` event logs an instance where a customer
+ * interacts with the product page and views a different variant than the
+ * initial `product_viewed` impression. This event is available on the Product
+ * page
+ */
+@Serializable
+public data class ProductVariantViewed (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: ProductVariantViewedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class ProductVariantViewedData (
+    public val productVariant: ProductVariant? = null
+)
+
+/**
+ * The `product_viewed` event logs an instance where a customer visited a
+ * product details page. This event is available on the product page
+ */
+@Serializable
+public data class ProductViewed (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: ProductViewedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class ProductViewedData (
+    public val productVariant: ProductVariant? = null
+)
+
+/**
+ * The `search_submitted` event logs an instance where a customer performed a
+ * search on the storefront. This event is available on the online store page
+ */
+@Serializable
+public data class SearchSubmitted (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val data: SearchSubmittedData? = null,
+): AnalyticsEvent
+
+@Serializable
+public data class SearchSubmittedData (
+    public val searchResult: SearchResult? = null
+)
+
+/**
+ * An object that contains the metadata of when a search has been performed.
+ */
+@Serializable
+public data class SearchResult (
+    public val productVariants: List<ProductVariant>? = null,
+
+    /**
+     * The search query that was executed
+     */
+    public val query: String? = null
+)
+
+/**
+ * This event represents any custom events emitted by partners or merchants via
+ * the `publish` method
+ */
+@Serializable
+public data class CustomEvent (
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val context: Context? = null,
+    public val customData: CustomData? = null,
+): AnalyticsEvent
+
+/**
+ * A free-form object representing data specific to a custom event provided by
+ * the custom event publisher
+ */
+public typealias CustomData = JsonObject
+
+@Serializable
+public data class InitData (
+    public val cart: Cart? = null,
+    public val checkout: Checkout? = null,
+    public val customer: Customer? = null,
+    public val productVariants: List<ProductVariant>? = null
+)
+
+/**
+ * A customer represents a customer account with the shop. Customer accounts
+ * store contact information for the customer, saving logged-in customers the
+ * trouble of having to provide it at every checkout.
+ */
+@Serializable
+public data class Customer (
+    /**
+     * The customer’s email address.
+     */
+    public val email: String? = null,
+
+    /**
+     * The customer’s first name.
+     */
+    public val firstName: String? = null,
+
+    /**
+     * The ID of the customer.
+     */
+    public val id: String? = null,
+
+    /**
+     * The customer’s last name.
+     */
+    public val lastName: String? = null,
+
+    /**
+     * The total number of orders that the customer has placed.
+     */
+    public val ordersCount: Double? = null,
+
+    /**
+     * The customer’s phone number.
+     */
+    public val phone: String? = null
+)
+
+/**
+ * A value given to a customer when a discount is applied to an order. The
+ * application of a discount with this value gives the customer the specified
+ * percentage off a specified item.
+ */
+@Serializable
+public data class PricingPercentageValue (
+    /**
+     * The percentage value of the object.
+     */
+    public val percentage: Double? = null
+)

--- a/lib/src/main/java/com/shopify/checkoutkit/messages/AnalyticsEventDecoder.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/messages/AnalyticsEventDecoder.kt
@@ -1,0 +1,81 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutkit.messages
+
+import android.util.Log
+import com.shopify.checkoutkit.LogWrapper
+import com.shopify.checkoutkit.WebToSdkEvent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
+
+internal class AnalyticsEventDecoder @JvmOverloads constructor(
+    private val decoder: Json,
+    private val log: LogWrapper = LogWrapper()
+) {
+    @Suppress("CyclomaticComplexMethod")
+    fun decode(decodedMsg: WebToSdkEvent): AnalyticsEvent? {
+        return try {
+            val rawEvent = decoder.decodeFromString<RawAnalyticsEvent>(decodedMsg.body)
+            when (AnalyticsEventType.fromEventName(rawEvent.name)) {
+                AnalyticsEventType.CART_VIEWED ->
+                    decoder.decodeFromJsonElement<CartViewed>(rawEvent.event)
+                AnalyticsEventType.CHECKOUT_ADDRESS_INFO_SUBMITTED ->
+                    decoder.decodeFromJsonElement<CheckoutAddressInfoSubmitted>(rawEvent.event)
+                AnalyticsEventType.CHECKOUT_COMPLETED ->
+                    decoder.decodeFromJsonElement<CheckoutCompleted>(rawEvent.event)
+                AnalyticsEventType.CHECKOUT_CONTACT_INFO_SUBMITTED ->
+                    decoder.decodeFromJsonElement<CheckoutContactInfoSubmitted>(rawEvent.event)
+                AnalyticsEventType.CHECKOUT_SHIPPING_INFO_SUBMITTED ->
+                    decoder.decodeFromJsonElement<CheckoutShippingInfoSubmitted>(rawEvent.event)
+                AnalyticsEventType.CHECKOUT_STARTED ->
+                    decoder.decodeFromJsonElement<CheckoutStarted>(rawEvent.event)
+                AnalyticsEventType.COLLECTION_VIEWED ->
+                    decoder.decodeFromJsonElement<CollectionViewed>(rawEvent.event)
+                AnalyticsEventType.PAGE_VIEWED ->
+                    decoder.decodeFromJsonElement<PageViewed>(rawEvent.event)
+                AnalyticsEventType.PAYMENT_INFO_SUBMITTED ->
+                    decoder.decodeFromJsonElement<PaymentInfoSubmitted>(rawEvent.event)
+                AnalyticsEventType.PRODUCT_ADDED_TO_CART ->
+                    decoder.decodeFromJsonElement<ProductAddedToCart>(rawEvent.event)
+                AnalyticsEventType.PRODUCT_REMOVED_FROM_CART ->
+                    decoder.decodeFromJsonElement<ProductRemovedFromCart>(rawEvent.event)
+                AnalyticsEventType.PRODUCT_VIEWED ->
+                    decoder.decodeFromJsonElement<ProductViewed>(rawEvent.event)
+                AnalyticsEventType.SEARCH_SUBMITTED ->
+                    decoder.decodeFromJsonElement<SearchSubmitted>(rawEvent.event)
+                null -> {
+                    // this could be a standard event we don't yet know about or a custom event
+                    if (rawEvent.event.containsKey("customData")) {
+                        decoder.decodeFromJsonElement<CustomEvent>(rawEvent.event)
+                    } else {
+                        log.w("CheckoutBridge", "Unrecognized standard analytics event received '${rawEvent.name}'")
+                        null
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            log.e("CheckoutBridge", "Failed to decode analytics event", e)
+            null
+        }
+    }
+}

--- a/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/CheckoutBridgeTest.kt
@@ -25,6 +25,8 @@ package com.shopify.checkoutkit
 import android.webkit.WebView
 import com.shopify.checkoutkit.CheckoutBridge.CheckoutWebOperation.COMPLETED
 import com.shopify.checkoutkit.CheckoutBridge.CheckoutWebOperation.MODAL
+import com.shopify.checkoutkit.messages.AnalyticsEvent
+import com.shopify.checkoutkit.messages.CheckoutStarted
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
@@ -36,6 +38,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -55,7 +58,7 @@ class CheckoutBridgeTest {
 
     @Test
     fun `postMessage calls web event processor onCheckoutViewComplete when completed message received`() {
-        checkoutBridge.postMessage(Json.encodeToString(CheckoutBridge.JSMessage(COMPLETED.key)))
+        checkoutBridge.postMessage(Json.encodeToString(WebToSdkEvent(COMPLETED.key)))
         verify(mockEventProcessor).onCheckoutViewComplete()
     }
 
@@ -63,7 +66,7 @@ class CheckoutBridgeTest {
     fun `postMessage calls web event processor onCheckoutModalToggled when modal message received - false`() {
         checkoutBridge.postMessage(
             Json.encodeToString(
-                CheckoutBridge.JSMessage(
+                WebToSdkEvent(
                     MODAL.key,
                     "false"
                 )
@@ -76,7 +79,7 @@ class CheckoutBridgeTest {
     fun `postMessage calls web event processor onCheckoutModalToggled when modal message received - true`() {
         checkoutBridge.postMessage(
             Json.encodeToString(
-                CheckoutBridge.JSMessage(
+                WebToSdkEvent(
                     MODAL.key,
                     "true"
                 )
@@ -87,7 +90,7 @@ class CheckoutBridgeTest {
 
     @Test
     fun `postMessage does not issue a msg to the event processor when unsupported message received`() {
-        checkoutBridge.postMessage(Json.encodeToString(CheckoutBridge.JSMessage("boom")))
+        checkoutBridge.postMessage(Json.encodeToString(WebToSdkEvent("boom")))
         verifyNoInteractions(mockEventProcessor)
     }
 
@@ -124,8 +127,6 @@ class CheckoutBridgeTest {
     @Test
     fun `sendMessage evaluates javascript on the provided WebView`() {
         val webView = mock<WebView>()
-        val initMessage = Json.encodeToString(CheckoutBridge.JSMessage("init"))
-        checkoutBridge.postMessage(initMessage)
         checkoutBridge.sendMessage(webView, CheckoutBridge.SDKOperation.Presented)
 
         verify(webView).evaluateJavascript("""|
@@ -176,5 +177,37 @@ class CheckoutBridgeTest {
         checkoutBridge.sendMessage(webView, CheckoutBridge.SDKOperation.Instrumentation(payload))
 
         Mockito.verify(webView).evaluateJavascript(expectedJavascript, null)
+    }
+
+    @Test
+    fun `calls on analytics received when valid analytics event received`() {
+        val eventString = """|
+            |{
+            |   "name":"analytics",
+            |   "body": "{
+            |       \"name\": \"checkout_started\",
+            |       \"event\": {
+            |           \"id\": \"sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B\",
+            |           \"name\": \"checkout_started\",
+            |           \"timestamp\": \"2023-12-20T16:39:23+0000\",
+            |           \"data\": {
+            |               \"checkout\": {
+            |                   \"order\": {
+            |                       \"id\": \"123\"
+            |                   }
+            |               }
+            |           }
+            |       }
+            |   }"
+            |}
+        |""".trimMargin()
+
+
+       checkoutBridge.postMessage(eventString)
+
+        val captor = argumentCaptor<AnalyticsEvent>()
+        verify(mockEventProcessor, timeout(2000).times(1)).onAnalyticsEvent(captor.capture())
+
+        assertThat(captor.firstValue).isInstanceOf(CheckoutStarted::class.java)
     }
 }

--- a/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/DefaultCheckoutEventProcessorTest.kt
@@ -25,6 +25,7 @@ package com.shopify.checkoutkit
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.ComponentActivity
+import com.shopify.checkoutkit.messages.AnalyticsEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -91,6 +92,7 @@ class DefaultCheckoutEventProcessorTest {
             override fun onCheckoutCompleted() {/* not implemented */}
             override fun onCheckoutFailed(error: CheckoutException) {/* not implemented */}
             override fun onCheckoutCanceled() {/* not implemented */}
+            override fun onAnalyticsEvent(analyticsEvent: AnalyticsEvent) {/* not implemented */}
         }
 
         val uri = Uri.parse("ftp:lsklsm")
@@ -116,6 +118,10 @@ class DefaultCheckoutEventProcessorTest {
                     override fun onCheckoutCanceled() {
                         /* not implemented */
                     }
+
+                    override fun onAnalyticsEvent(analyticsEvent: AnalyticsEvent) {
+                        /* not implemented */
+                    }
                 }
 
         val error = object : CheckoutException("error description") {}
@@ -130,6 +136,7 @@ class DefaultCheckoutEventProcessorTest {
             override fun onCheckoutCompleted() {/* not implemented */}
             override fun onCheckoutFailed(error: CheckoutException) {/* not implemented */}
             override fun onCheckoutCanceled() {/* not implemented */}
+            override fun onAnalyticsEvent(analyticsEvent: AnalyticsEvent) {/* not implemented */}
         }
     }
 }

--- a/lib/src/test/java/com/shopify/checkoutkit/InteropTest.java
+++ b/lib/src/test/java/com/shopify/checkoutkit/InteropTest.java
@@ -3,15 +3,19 @@ package com.shopify.checkoutkit;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import android.app.Activity;
-
 import androidx.activity.ComponentActivity;
 import androidx.annotation.NonNull;
+import com.shopify.checkoutkit.messages.AnalyticsEvent;
+import com.shopify.checkoutkit.messages.CheckoutStarted;
+import com.shopify.checkoutkit.messages.CheckoutStartedData;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+
+import kotlinx.serialization.json.Json;
 
 @RunWith(RobolectricTestRunner.class)
 public class InteropTest {
@@ -26,6 +30,11 @@ public class InteropTest {
     @Test
     public void canInstantiateCustomEventProcessorWithDefaultArg() {
         DefaultCheckoutEventProcessor processor = new DefaultCheckoutEventProcessor(activity) {
+            @Override
+            public void onAnalyticsEvent(@NonNull AnalyticsEvent analyticsEvent) {
+
+            }
+
             @Override
             public void onCheckoutCompleted() {
 
@@ -44,4 +53,42 @@ public class InteropTest {
 
         assertThat(processor).isNotNull();
     }
+
+    // java tests lack access to internal kotlin classes in the project
+    @SuppressWarnings("all")
+    @Test
+    public void canAccessFieldsOnAnalyticsEvents() {
+        String orderId = "123";
+        String eventString = "{" +
+            "\"name\": \"checkout_started\"," +
+            "\"event\": {" +
+                "\"id\": \"sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B\"," +
+                "\"name\": \"checkout_started\"," +
+                "\"timestamp\": \"2023-12-20T16:39:23+0000\"," +
+                "\"data\": {" +
+                    "\"checkout\": {" +
+                        "\"order\": {" +
+                        "\"id\": \"" + orderId + "\"" +
+                        "}" +
+                    "}" +
+                "}" +
+            "}" +
+        "}";
+
+        WebToSdkEvent webEvent = new WebToSdkEvent("analytics", eventString);
+        Json json = Json.Default;
+
+        com.shopify.checkoutkit.messages.AnalyticsEventDecoder decoder = new com.shopify.checkoutkit.messages.AnalyticsEventDecoder(
+            json
+        );
+
+        AnalyticsEvent event = decoder.decode(webEvent);
+
+        assertThat(event).isInstanceOf(CheckoutStarted.class);
+        CheckoutStarted checkoutStarted = (CheckoutStarted) event;
+        CheckoutStartedData checkoutStartedData = checkoutStarted.getData();
+        String checkoutStartedOrderId = checkoutStartedData.getCheckout().getOrder().getId();
+
+        assertThat(checkoutStartedOrderId).isEqualTo(orderId);
+     }
 }

--- a/lib/src/test/java/com/shopify/checkoutkit/messages/AnalyticsEventDecoderTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/messages/AnalyticsEventDecoderTest.kt
@@ -1,0 +1,227 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutkit.messages
+
+import com.shopify.checkoutkit.LogWrapper
+import com.shopify.checkoutkit.WebToSdkEvent
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+
+class AnalyticsEventDecoderTest {
+
+    private val logWrapper = mock<LogWrapper>()
+    private val decoder = AnalyticsEventDecoder(Json { ignoreUnknownKeys = true }, logWrapper)
+
+    @Test
+    fun `should deserialize a standard event - checkout started`() {
+        val event = """|
+            |{
+            |    "name": "checkout_started",
+            |    "event": {
+            |        "id": "sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B",
+            |        "name": "checkout_started",
+            |        "timestamp": "2023-12-20T16:39:23+0000",
+            |        "data": {
+            |            "checkout": {
+            |                "order": {
+            |                    "id": "123"
+            |                }
+            |            }
+            |        }
+            |    }
+            |}
+        |""".trimMargin()
+            .toWebToSdkEvent()
+
+
+        val result = decoder.decode(event)
+
+        assertThat(result).isInstanceOf(CheckoutStarted::class.java)
+
+        val checkoutStarted = result as CheckoutStarted
+        assertThat(checkoutStarted.name).isEqualTo("checkout_started")
+        assertThat(checkoutStarted.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
+        assertThat(checkoutStarted.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
+        assertThat(checkoutStarted.data?.checkout?.order?.id).isEqualTo("123")
+
+        verifyNoInteractions(logWrapper)
+    }
+
+    @Test
+    fun `should deserialize a standard event - CheckoutCompleted`() {
+        val event = """|
+            |{
+            |    "name": "checkout_completed",
+            |    "event": {
+            |        "id": "sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B",
+            |        "name": "checkout_completed",
+            |        "timestamp": "2023-12-20T16:39:23+0000",
+            |        "data": {
+            |            "checkout": {
+            |                "totalPrice": {
+            |                   "amount": 123.3,
+            |                   "currencyCode": "USD"
+            |                },
+            |                "order": {
+            |                    "id": "123"
+            |                }
+            |            }
+            |        }
+            |    }
+            |}
+        |""".trimMargin()
+            .toWebToSdkEvent()
+
+
+        val result = decoder.decode(event)
+
+        assertThat(result).isInstanceOf(CheckoutCompleted::class.java)
+
+        val checkoutStarted = result as CheckoutCompleted
+        assertThat(checkoutStarted.name).isEqualTo("checkout_completed")
+        assertThat(checkoutStarted.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
+        assertThat(checkoutStarted.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
+        assertThat(checkoutStarted.data?.checkout?.order?.id).isEqualTo("123")
+        assertThat(checkoutStarted.data?.checkout?.totalPrice?.amount).isEqualTo(123.3)
+        assertThat(checkoutStarted.data?.checkout?.totalPrice?.currencyCode).isEqualTo("USD")
+
+        verifyNoInteractions(logWrapper)
+    }
+
+    @Test
+    fun `should deserialize a custom event`() {
+        val event = """|
+            |{
+            |    "name": "my_custom_event",
+            |    "event": {
+            |        "id": "sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B",
+            |        "name": "my_custom_event",
+            |        "timestamp": "2023-12-20T16:39:23+0000",
+            |        "customData": {
+            |            "a": {
+            |                "b": {
+            |                    "c": "d"
+            |                }
+            |            }
+            |        }
+            |    }
+            |}
+        |""".trimMargin()
+            .toWebToSdkEvent()
+
+        val result = decoder.decode(event)
+
+        assertThat(result).isInstanceOf(CustomEvent::class.java)
+
+        val customEvent = result as CustomEvent
+        assertThat(customEvent.name).isEqualTo("my_custom_event")
+        assertThat(customEvent.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
+        assertThat(customEvent.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
+        val customData = Json.decodeFromJsonElement<ExampleClientDefinedType>(customEvent.customData as JsonObject)
+        assertThat(customData.a.b.c).isEqualTo("d")
+
+        verifyNoInteractions(logWrapper)
+    }
+
+    @Test
+    fun `should return null for a standard event we don't know about`() {
+        val event = """|
+            |{
+            |    "name": "new_standard_event",
+            |    "event": {
+            |        "id": "sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B",
+            |        "name": "new_standard_event",
+            |        "timestamp": "2023-12-20T16:39:23+0000",
+            |        "data": {
+            |            "a": {
+            |                "b": {
+            |                    "c": "d"
+            |                }
+            |            }
+            |        }
+            |    }
+            |}
+        |""".trimMargin()
+            .toWebToSdkEvent()
+
+        val result = decoder.decode(event)
+
+        assertThat(result).isNull()
+        verify(logWrapper).w(
+            "CheckoutBridge",
+            "Unrecognized standard analytics event received 'new_standard_event'"
+        )
+    }
+
+    @Test
+    fun `should return null if event cannot be decoded`() {
+        val event = """|
+            |{
+            |    "name": "cart_viewed",
+            |    "event": {
+            |        "id": "sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B",
+            |}
+        |""".trimMargin()
+            .toWebToSdkEvent()
+
+        val result = decoder.decode(event)
+
+        assertThat(result).isNull()
+        verify(logWrapper).e(
+            eq("CheckoutBridge"),
+            eq("Failed to decode analytics event"),
+            any()
+        )
+    }
+}
+
+private fun String.toWebToSdkEvent(): WebToSdkEvent {
+    return WebToSdkEvent(
+        name = "analytics",
+        body = this,
+    )
+}
+
+@Serializable
+data class ExampleClientDefinedType(
+    val a: B
+)
+
+@Serializable
+data class B(
+    val b: C
+)
+
+@Serializable
+data class C(
+    val c: String
+)

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
@@ -22,6 +22,7 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.navigation
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
@@ -38,6 +39,7 @@ import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartViewModel
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.product.ProductView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsViewModel
+import com.shopify.checkoutkit.messages.AnalyticsEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -101,6 +103,10 @@ fun CheckoutSdkNavHost(
 
                     override fun onCheckoutCanceled() {
                         // optionally respond to checkout being canceled/closed
+                    }
+
+                    override fun onAnalyticsEvent(analyticsEvent: AnalyticsEvent) {
+                        Log.e("CheckoutSdkNavHost", "Received analytics event $analyticsEvent")
                     }
                 }
             )


### PR DESCRIPTION
### What are you trying to accomplish?

- Listen for analytics events from checkout.
- Deserialize them into a relevant type implementing `AnalyticsEvent`
- Emit event via `onAnalyticsEvent(analyticsEvent: AnalayticsEvent)` in the checkout event processor.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
