### PR TITLE
Ensure webview isn't scrolled down on open

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -43,6 +43,7 @@ import android.widget.ProgressBar
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.children
 
 internal class CheckoutDialog(
     private val checkoutUrl: String,
@@ -133,7 +134,10 @@ internal class CheckoutDialog(
 
     private fun hideProgressBar() {
         findViewById<FrameLayout>(R.id.checkoutSdkLoadingSpinner).visibility = GONE
-        findViewById<CheckoutWebViewContainer>(R.id.checkoutSdkContainer).visibility = VISIBLE
+        findViewById<CheckoutWebViewContainer>(R.id.checkoutSdkContainer).apply {
+            children.firstOrNull()?.scrollY = 0
+            visibility = VISIBLE
+        }
     }
 
     @ColorInt


### PR DESCRIPTION
### What are you trying to accomplish?

Ensure that the webview is scrolled to top when the loading spinner is dismissed. N.B. this will not work with the sticky pay button.

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
